### PR TITLE
Fix margin calculation for all months

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -99,8 +99,6 @@ def concentrado_anual_view(request):
 
         # Para cada mes: sumo los ingresos definidos y resto los costos definidos
         for mes in MESES:
-            if mes != 'Enero':
-                continue
             
             print(f"  ► Calculando {nombre_margen} para mes {mes}")
 


### PR DESCRIPTION
## Summary
- calculate profit margins for every month instead of only January

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843180b7f2483259232a4d252df3708